### PR TITLE
Fixes yii2mod/yii2-ion-slider#9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "yiisoft/yii2": "*",
-        "bower-asset/ionrangeslider": "*"
+        "bower-asset/ionrangeslider": ">=2.0 <=2.2"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.0"


### PR DESCRIPTION
The *bower-asset/ionrangeslider* dependency behind this Yii2 module has changed since version 2.3.0, and there are no `css/ion.rangeSlider.skinHTML5.css` and `css/normalize.css` files anymore.

As quick fix,  the version range of the *bower-asset/ionrangeslider* dependency shall be limited.